### PR TITLE
feat: Add PO to CR conversion feature

### DIFF
--- a/src/app/api/po/[id]/convert/route.ts
+++ b/src/app/api/po/[id]/convert/route.ts
@@ -25,10 +25,11 @@ export async function POST(
       return NextResponse.json({ error: "Purchase Order not found" }, { status: 404 });
     }
 
-    // Validate that PO is approved
-    if (po.status !== 'APPROVED') {
+    // Validate that PO status allows for CR conversion
+    const allowedStatuses = ['APPROVED', 'ORDERED', 'DELIVERED'];
+    if (!allowedStatuses.includes(po.status)) {
       return NextResponse.json(
-        { error: "Purchase Order must be approved before converting to Check Request" },
+        { error: `Purchase Order status must be one of: ${allowedStatuses.join(', ')} to be converted.` },
         { status: 400 }
       );
     }


### PR DESCRIPTION
This commit introduces the full feature to convert a Purchase Order (PO) to a Check Request (CR).

Backend:
- Creates a new POST route at `/api/po/[id]/convert` to handle the conversion.
- Corrects the validation logic to allow conversion for POs with status 'APPROVED', 'ORDERED', or 'DELIVERED', matching the frontend logic.
- Deletes the old, incorrect route at `/api/cr/po/route.ts`.
- Fixes several pre-existing issues in the test suite related to incomplete mock data.

Frontend:
- Updates the PO detail page (`src/app/po/[id]/page.tsx`) to call the new, correct API endpoint.
- Adds a dropdown UI to allow the user to select a `paymentMethod` before conversion.
- Sends the selected `paymentMethod` in the request body to the backend.
- Improves error handling to display alerts to the user.