### PR TITLE
Fix: Correct PR approval workflow

### DIFF
--- a/src/app/api/pr/[id]/route.ts
+++ b/src/app/api/pr/[id]/route.ts
@@ -59,24 +59,26 @@ export async function PATCH(
     }
 
     const body = await request.json();
+    const { status, approverId } = body;
 
-    if (!body.status) {
+    if (!status && !approverId) {
       return NextResponse.json(
-        { error: "Status is required" },
+        { error: "At least one of status or approverId is required" },
         { status: 400 }
       );
     }
 
-    // Validate status
-    const validStatuses = Object.values(PRStatus);
-    if (!validStatuses.includes(body.status)) {
-      return NextResponse.json(
-        { error: "Invalid status" },
-        { status: 400 }
-      );
+    if (status) {
+      const validStatuses = Object.values(PRStatus);
+      if (!validStatuses.includes(status)) {
+        return NextResponse.json(
+          { error: "Invalid status" },
+          { status: 400 }
+        );
+      }
     }
 
-    const pr = await updatePRStatus(id, body.status, session);
+    const pr = await updatePRStatus(id, status, session, approverId);
 
     if (!pr) {
       return NextResponse.json({ error: "PR not found" }, { status: 404 });


### PR DESCRIPTION
This commit fixes a bug in the Payment Request (PR) approval workflow. The API endpoint for updating a PR's status was not correctly handling the assignment of an approver, which prevented the PR from being moved to the 'PENDING_APPROVAL' status.

The PATCH handler in `src/app/api/pr/[id]/route.ts` has been updated to correctly extract the `approverId` from the request body and pass it to the `updatePRStatus` function. This change aligns the PR module's behavior with the IOM and PO modules, ensuring a consistent and functional approval process across the application.

This change was made as part of a broader review of the IOM, PO, and PR workflows, which were found to be otherwise working correctly. The review also verified that the recent module name change from "CR check request" to "PR payment request" was implemented successfully throughout the codebase.