### PR TITLE
Fix: Correct API responses and frontend data access

### DIFF
--- a/src/app/api/iom/route.ts
+++ b/src/app/api/iom/route.ts
@@ -43,14 +43,14 @@ export async function GET(req: NextRequest) {
       Object.fromEntries(req.nextUrl.searchParams)
     );
 
-    const ioms = await getIOMs({
+    const { ioms, total } = await getIOMs({
       page,
       pageSize,
       search,
       status: status || [],
       session,
     });
-    return NextResponse.json(ioms);
+    return NextResponse.json({ ioms, total });
   } catch (error) {
     if (error instanceof ZodError) {
       return NextResponse.json({ error: error.message }, { status: 400 });

--- a/src/app/api/po/route.ts
+++ b/src/app/api/po/route.ts
@@ -25,13 +25,7 @@ export async function GET(request: NextRequest) {
       status,
     });
 
-    return NextResponse.json({
-      data: purchaseOrders,
-      total,
-      page,
-      pageSize,
-      pageCount: Math.ceil(total / pageSize),
-    });
+    return NextResponse.json({ pos: purchaseOrders, total });
   } catch (error) {
     console.error("Error fetching POs:", error);
     return NextResponse.json(

--- a/src/app/api/pr/route.ts
+++ b/src/app/api/pr/route.ts
@@ -27,13 +27,7 @@ export async function GET(request: NextRequest) {
       status,
     });
 
-    return NextResponse.json({
-      data: paymentRequests,
-      total,
-      page,
-      pageSize,
-      pageCount: Math.ceil(total / pageSize),
-    });
+    return NextResponse.json({ prs: paymentRequests, total });
   } catch (error) {
     console.error("Error fetching PRs:", error);
     return NextResponse.json(

--- a/src/app/iom/page.tsx
+++ b/src/app/iom/page.tsx
@@ -67,9 +67,9 @@ export default function IOMListPage() {
     }
   };
 
-  const ioms = data?.data || [];
+  const ioms = data?.ioms || [];
   const total = data?.total || 0;
-  const pageCount = data?.pageCount || 0;
+  const pageCount = Math.ceil(total / pageSize);
 
   const handleSearch = (query: string) => {
     setPage(1);

--- a/src/app/po/page.tsx
+++ b/src/app/po/page.tsx
@@ -66,9 +66,9 @@ export default function POListPage() {
     }
   };
 
-  const pos = data?.data || [];
+  const pos = data?.pos || [];
   const total = data?.total || 0;
-  const pageCount = data?.pageCount || 0;
+  const pageCount = Math.ceil(total / pageSize);
 
   const handleSearch = (query: string) => {
     setPage(1);

--- a/src/app/pr/page.tsx
+++ b/src/app/pr/page.tsx
@@ -67,9 +67,9 @@ export default function PRListPage() {
     }
   };
 
-  const prs = data?.data || [];
+  const prs = data?.prs || [];
   const total = data?.total || 0;
-  const pageCount = data?.pageCount || 0;
+  const pageCount = Math.ceil(total / pageSize);
 
   const handleSearch = (query: string) => {
     setPage(1);


### PR DESCRIPTION
This commit fixes a critical bug where the frontend list pages (IOM, PO, PR) were not displaying any data, even when the API was returning results.

The issue was a mismatch between the data structure returned by the backend APIs and the structure expected by the frontend components.

- The backend APIs for IOMs, POs, and PRs have been updated to return data in the format `{ ioms: [...] }`, `{ pos: [...] }`, and `{ prs: [...] }` respectively, along with the `total` count.
- The corresponding frontend list pages have been updated to correctly access the data from these properties (e.g., `data.ioms` instead of `data.data`).
- The page count calculation on the list pages has also been corrected.

This commit also includes the previous fixes for the login issue, the admin role misidentification, and the IOM creation error.

With these changes, the application should now be fully functional and stable.