### PR TITLE
Fix: Align frontend and backend permissions for document views

### DIFF
--- a/src/app/po/[id]/page.tsx
+++ b/src/app/po/[id]/page.tsx
@@ -30,7 +30,7 @@ export default function PODetailPage() {
   const [selectedApprover, setSelectedApprover] = useState<string>('');
 
   // Add permission check to view PO
-  const canViewPO = useHasPermission('VIEW_PO');
+  const canViewPO = useHasPermission('READ_PO');
   const canApprove = useHasPermission('APPROVE_PO');
   const canReject = useHasPermission('REJECT_PO');
   const canReview = useHasPermission('REVIEW_PO');

--- a/src/app/pr/[id]/page.tsx
+++ b/src/app/pr/[id]/page.tsx
@@ -34,7 +34,7 @@ export default function PRDetailPage() {
   const [selectedApprover, setSelectedApprover] = useState<string>('');
 
   // Added permission check to view PR
-  const canViewPR = useHasPermission('VIEW_PR');
+  const canViewPR = useHasPermission('READ_PR');
   const canApprove = useHasPermission('APPROVE_PR');
   const canReject = useHasPermission('REJECT_PR');
   const canCancel = useHasPermission('CANCEL_PR');


### PR DESCRIPTION
This commit provides the definitive fix for a persistent authorization issue where the admin user was unable to view Purchase Order (PO) and Payment Request (PR) detail pages.

The root cause was an inconsistency between the permission strings checked by the frontend components and the permissions provided by the backend. The frontend pages were checking for `VIEW_PO` and `VIEW_PR`, while the backend and the user's session only provided `READ_PO` and `READ_PR`.

This commit resolves the issue by modifying the frontend components to check for the correct permission strings:
- **`src/app/po/[id]/page.tsx`**: The `useHasPermission` hook now correctly checks for `'READ_PO'`.
- **`src/app/pr/[id]/page.tsx`**: The `useHasPermission` hook now correctly checks for `'READ_PR'`.

This change ensures that the entire data flow for authorization, from the database seed to the API to the frontend UI, is consistent, finally resolving the 'Access Denied' errors.

This commit is the culmination of several debugging steps, including correcting API-level permission checks and standardizing the permission naming scheme. All related issues should now be resolved.