### PR TITLE
feat: Filter approvers by role and permission

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -92,16 +92,15 @@ export async function GET(req: Request) {
       authorize(session, 'MANAGE_USERS');
     }
 
-    let whereClause: any = {};
+    let whereClause: any = { role: {} };
     if (roleName) {
-      whereClause.role = { name: roleName };
-    } else if (permissionName) {
-      whereClause.role = {
-        permissions: {
-          some: {
-            permission: {
-              name: permissionName,
-            },
+      whereClause.role.name = roleName;
+    }
+    if (permissionName) {
+      whereClause.role.permissions = {
+        some: {
+          permission: {
+            name: permissionName,
           },
         },
       };

--- a/src/app/po/[id]/page.tsx
+++ b/src/app/po/[id]/page.tsx
@@ -61,8 +61,8 @@ export default function PODetailPage() {
 
   const fetchApprovers = useCallback(async () => {
     try {
-      // FIX: Fetch users by permission instead of hardcoded role
-      const response = await fetch('/api/users?permission=APPROVE_PO');
+      // Fetch users who are managers and have the permission to approve POs
+      const response = await fetch('/api/users?permission=APPROVE_PO&role=MANAGER');
       if (response.ok) {
         const data = await response.json();
         setApprovers(data);

--- a/src/app/pr/[id]/page.tsx
+++ b/src/app/pr/[id]/page.tsx
@@ -59,7 +59,8 @@ export default function PRDetailPage() {
 
   const fetchApprovers = useCallback(async () => {
     try {
-      const response = await fetch('/api/users?permission=APPROVE_PR'); // FIX: Fetch users by permission instead of hardcoded role
+      // Fetch users who are managers and have the permission to approve PRs
+      const response = await fetch('/api/users?permission=APPROVE_PR&role=MANAGER');
       if (response.ok) {
         const data = await response.json();
         setApprovers(data);


### PR DESCRIPTION
This change updates the user API to allow filtering by both role and permission simultaneously. The Purchase Order (PO) and Purchase Requisition (PR) detail pages have been updated to fetch approvers who have the 'MANAGER' role and the appropriate approval permission.

This ensures that the approver selection dropdowns only contain users who are managers, as requested by the user, and fixes the original bug where the approver list was not being fetched correctly.