### PR TITLE
fix: Correct approver list fetching and logic

### DIFF
--- a/src/app/pr/[id]/page.tsx
+++ b/src/app/pr/[id]/page.tsx
@@ -80,11 +80,15 @@ export default function PRDetailPage() {
     if (params.id) {
       fetchPR();
     }
-    // Only fetch approvers if the user has a relevant permission
-    if (canApprove) {
+  }, [params.id, canViewPR, fetchPR]);
+
+  useEffect(() => {
+    // Fetch approvers when the creator is viewing a draft PR,
+    // so they can select an approver when submitting.
+    if (isCreator && pr?.status === PRStatus.DRAFT) {
       fetchApprovers();
     }
-  }, [params.id, canViewPR, canApprove, fetchPR, fetchApprovers]);
+  }, [isCreator, pr, fetchApprovers]);
 
   const updateStatus = async (newStatus?: PRStatus, approverId?: string) => {
     setUpdating(true);


### PR DESCRIPTION
This commit addresses several issues related to fetching approvers and reviewers in the PO and PR modules.

- The `/api/users` endpoint is updated to allow filtering by both `role` and `permission` query parameters simultaneously.
- The PO and PR detail pages are updated to request users with the 'MANAGER' role when fetching approver lists, ensuring only managers are shown.
- The logic on the PR detail page is corrected to fetch the approver list for the creator of the PR, fixing a bug where the list would appear empty.