### PR TITLE
Fix: Overhaul notifications and standardize currency symbols

### DIFF
--- a/src/app/api/pr/[id]/route.test.ts
+++ b/src/app/api/pr/[id]/route.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PATCH } from './route';
 import { auth } from '@/lib/auth-config';
 import { updatePRStatus } from '@/lib/pr';
-import { PRStatus } from '@/types/pr';
+import { PRStatus, PaymentRequest as PaymentRequestType } from '@/types/pr';
 import { Session } from 'next-auth';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 
 // Mock dependencies
 vi.mock('next/server', async (importOriginal) => {
-    const mod = await importOriginal() as any;
+    const mod = await importOriginal<typeof import('next/server')>();
     return {
         ...mod,
         NextResponse: {
@@ -19,7 +19,6 @@ vi.mock('next/server', async (importOriginal) => {
                 }
             }),
         },
-        NextRequest: mod.NextRequest,
     };
 });
 vi.mock('@/lib/auth-config', () => ({
@@ -99,7 +98,7 @@ describe('PATCH /api/pr/[id]', () => {
 
   it('should successfully update the PR status and return 200', async () => {
     const updatedPr = { id: 'pr-123', status: PRStatus.APPROVED };
-    vi.mocked(updatePRStatus).mockResolvedValue(updatedPr as any);
+    vi.mocked(updatePRStatus).mockResolvedValue(updatedPr as PaymentRequestType);
 
     const request = new NextRequest('http://localhost', {
       method: 'PATCH',


### PR DESCRIPTION
This commit addresses two main issues:
1.  Notification System:
    - Overhauled the notification logic for IOMs, POs, and PRs.
    - Notifications are now sent upon document creation to the assigned reviewer and approver.
    - Status update notifications are now more specific, distinguishing between final decisions (Approved/Rejected) and intermediate steps.
    - All relevant parties (creator, reviewer, approver) are now notified of final outcomes.

2.  Currency Symbols:
    - Standardized the currency symbol to `₹` (rupee) across the application, replacing the `$` symbol in the IOM create and edit forms to ensure UI consistency.