### PR TITLE
fix: Correct data mapping in PR creation

### DIFF
--- a/src/lib/pr.ts
+++ b/src/lib/pr.ts
@@ -137,7 +137,7 @@ type CreatePrData = z.infer<typeof createPrSchema> & {
 
 export async function createPaymentRequest(data: CreatePrData, session: Session) {
   authorize(session, 'CREATE_PR');
-  const { status, ...restOfData } = data;
+  const { status, reviewerId, approverId, ...restOfData } = data;
   if (restOfData.poId) {
     const po = await prisma.purchaseOrder.findUnique({
       where: { id: restOfData.poId },
@@ -160,8 +160,8 @@ export async function createPaymentRequest(data: CreatePrData, session: Session)
     // Explicitly construct the data for prisma create
     const prData = {
       ...restOfData,
-      reviewedById: restOfData.reviewerId, // map reviewerId to reviewedById
-      approvedById: restOfData.approverId, // map approverId to approvedById
+      reviewedById: reviewerId, // map reviewerId to reviewedById
+      approvedById: approverId, // map approverId to approvedById
       prNumber: prNumber,
       status: status || PRStatus.PENDING_APPROVAL,
     };


### PR DESCRIPTION
This commit fixes a bug in the `createPaymentRequest` function that caused an error when converting a Purchase Order to a Payment Request.

The function was incorrectly passing `reviewerId` and `approverId` fields directly to the Prisma client, which expects `reviewedById` and `approvedById`. This resulted in a `PrismaClientValidationError`.

The fix involves destructuring `reviewerId` and `approverId` from the input data object and ensuring only the correctly named fields (`reviewedById`, `approvedById`) are passed to the database creation call.