### PR TITLE
fix: Correct JSON key in PR API response

### DIFF
--- a/src/app/api/pr/route.ts
+++ b/src/app/api/pr/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
       status,
     });
 
-    return NextResponse.json({ prs: paymentRequests, total });
+    return NextResponse.json({ paymentRequests, total });
   } catch (error) {
     console.error("Error fetching PRs:", error);
     return NextResponse.json(


### PR DESCRIPTION
This commit fixes a bug where the Payment Requisition (PR) list page was appearing empty despite data existing in the database.

The issue was caused by a mismatch in the JSON key for the list of PRs. The API endpoint at `/api/pr` was returning the data under the key `prs`, while the frontend page at `/pr` was expecting the key to be `paymentRequests`.

This commit changes the API response to use the `paymentRequests` key, aligning it with the frontend's expectation and resolving the bug.