### PR TITLE
feat(iom): Make item section optional in IOM creation

### DIFF
--- a/src/app/iom/create/page.tsx
+++ b/src/app/iom/create/page.tsx
@@ -37,9 +37,7 @@ export default function CreateIOMPage() {
     reviewerId: "",
     approverId: "",
   });
-  const [items, setItems] = useState<IOMItem[]>([
-    { itemName: "", description: "", quantity: 1, unitPrice: 0, totalPrice: 0 },
-  ]);
+  const [items, setItems] = useState<IOMItem[]>([]);
   const [errors, setErrors] = useState<Record<string, string[]>>({});
   const [reviewers, setReviewers] = useState<User[]>([]);
   const [approvers, setApprovers] = useState<User[]>([]);
@@ -74,9 +72,7 @@ export default function CreateIOMPage() {
   };
 
   const removeItem = (index: number) => {
-    if (items.length > 1) {
-      setItems(items.filter((_, i) => i !== index));
-    }
+    setItems(items.filter((_, i) => i !== index));
   };
 
   const updateItem = (index: number, field: keyof IOMItem, value: string | number) => {
@@ -262,86 +258,97 @@ export default function CreateIOMPage() {
         </div>
 
         {/* Items Section */}
-        <div>
-          <div className="flex justify-between items-center mb-4">
-            <h3 className="text-lg font-medium text-gray-900">Items</h3>
+        <div className="border-t pt-6">
+          {items.length === 0 ? (
             <button
               type="button"
               onClick={addItem}
-              className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded-md text-sm"
+              className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 border-2 border-dashed border-gray-300 px-4 py-3 rounded-md text-sm font-medium"
             >
-              Add Item
+              + Add Item Section (for purchases)
             </button>
-          </div>
+          ) : (
+            <div>
+              <div className="flex justify-between items-center mb-4">
+                <h3 className="text-lg font-medium text-gray-900">Items</h3>
+                <button
+                  type="button"
+                  onClick={addItem}
+                  className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded-md text-sm"
+                >
+                  Add Another Item
+                </button>
+              </div>
 
-          {items.map((item, index) => (
-            <div key={index} className="border rounded-lg p-4 mb-4 relative">
-              <button
-                type="button"
-                onClick={() => removeItem(index)}
-                className="absolute top-2 right-2 text-red-600 hover:text-red-800"
-              >
-                ×
-              </button>
+              {items.map((item, index) => (
+                <div key={index} className="border rounded-lg p-4 mb-4 relative">
+                  <button
+                    type="button"
+                    onClick={() => removeItem(index)}
+                    className="absolute top-2 right-2 text-red-600 hover:text-red-800"
+                  >
+                    ×
+                  </button>
 
-              <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Item Name *</label>
-                  <input
-                    type="text"
-                    required
-                    value={item.itemName}
-                    onChange={(e) => updateItem(index, "itemName", e.target.value)}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                  />
+                  <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700">Item Name</label>
+                      <input
+                        type="text"
+                        value={item.itemName}
+                        onChange={(e) => updateItem(index, "itemName", e.target.value)}
+                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700">Description</label>
+                      <input
+                        type="text"
+                        value={item.description}
+                        onChange={(e) => updateItem(index, "description", e.target.value)}
+                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700">Quantity</label>
+                      <input
+                        type="number"
+                        min="1"
+                        value={item.quantity}
+                        onChange={(e) => updateItem(index, "quantity", parseInt(e.target.value) || 1)}
+                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700">
+                        Unit Price (₹)
+                      </label>
+                      <input
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={item.unitPrice}
+                        onChange={(e) =>
+                          updateItem(index, "unitPrice", parseFloat(e.target.value) || 0)
+                        }
+                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                      />
+                    </div>
+                  </div>
+                  <div className="mt-2 text-right">
+                    <span className="text-sm font-medium">Total: ₹{item.totalPrice.toFixed(2)}</span>
+                  </div>
                 </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Description</label>
-                  <input
-                    type="text"
-                    value={item.description}
-                    onChange={(e) => updateItem(index, "description", e.target.value)}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Quantity</label>
-                  <input
-                    type="number"
-                    min="1"
-                    value={item.quantity}
-                    onChange={(e) => updateItem(index, "quantity", parseInt(e.target.value) || 1)}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">
-                    Unit Price (₹)
-                  </label>
-                  <input
-                    type="number"
-                    step="0.01"
-                    min="0"
-                    value={item.unitPrice}
-                    onChange={(e) =>
-                      updateItem(index, "unitPrice", parseFloat(e.target.value) || 0)
-                    }
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                  />
+              ))}
+
+              <div className="mt-4 p-4 bg-gray-50 rounded-lg">
+                <div className="flex justify-between items-center">
+                  <span className="text-lg font-semibold">Grand Total:</span>
+                  <span className="text-xl font-bold">₹{totalAmount.toFixed(2)}</span>
                 </div>
               </div>
-              <div className="mt-2 text-right">
-                <span className="text-sm font-medium">Total: ₹{item.totalPrice.toFixed(2)}</span>
-              </div>
             </div>
-          ))}
-
-          <div className="mt-4 p-4 bg-gray-50 rounded-lg">
-            <div className="flex justify-between items-center">
-              <span className="text-lg font-semibold">Grand Total:</span>
-              <span className="text-xl font-bold">₹{totalAmount.toFixed(2)}</span>
-            </div>
-          </div>
+          )}
         </div>
 
         <div className="flex justify-end space-x-4">

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -72,7 +72,7 @@ export const createIomSchema = z.object({
   to: z.string().min(1, 'To is required.'),
   subject: z.string().min(1, 'Subject is required.'),
   content: z.string().optional(),
-  items: z.array(createIomItemSchema).min(1, 'At least one item is required.'),
+  items: z.array(createIomItemSchema).optional(),
   requestedById: z.string().cuid(),
   reviewerId: z.string().cuid('Invalid reviewer.'),
   approverId: z.string().cuid('Invalid approver.'),


### PR DESCRIPTION
This commit addresses the requirement to allow the creation of Internal Office Memos (IOMs) without any items, catering to general-purpose memos like office circulars.

The key changes are:
- The backend validation schema (`src/lib/schemas.ts`) has been updated to make the `items` array optional.
- The IOM creation form (`src/app/iom/create/page.tsx`) has been modified to:
  - Initialize the items list as an empty array.
  - Conditionally display an "Add Item Section" button, keeping the UI clean for item-less IOMs.
  - Allow the removal of all items from the form.