### PR TITLE
fix(iom): Handle undefined items in createIOM

### DIFF
--- a/src/lib/iom.test.ts
+++ b/src/lib/iom.test.ts
@@ -84,6 +84,41 @@ describe('IOM Functions', () => {
 
       expect(prisma.iOM.create).toHaveBeenCalledTimes(2);
     });
+
+    it('should correctly create an IOM when the items array is not provided (undefined)', async () => {
+      const iomData = {
+        title: 'Test IOM without items',
+        from: 'Dept C',
+        to: 'Dept D',
+        subject: 'No Items Test',
+        preparedById: 'user-2',
+        requestedById: 'user-2',
+        // 'items' property is intentionally omitted
+      };
+      const session = mockUserSession(['CREATE_IOM']);
+      vi.mocked(authorize).mockReturnValue(true);
+
+      const createdIomMock = { id: 'new-iom-id-no-items', ...iomData, items: [] } as unknown as IOM;
+      vi.mocked(prisma.iOM.create).mockResolvedValue(createdIomMock);
+
+      // We need to cast because the base type expects `items`
+      await createIOM(iomData as any, session);
+
+      expect(authorize).toHaveBeenCalledWith(session, 'CREATE_IOM');
+
+      // Check that prisma.create was called with an empty array for items
+      expect(prisma.iOM.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            items: {
+              create: [], // This is the crucial check
+            },
+            totalAmount: 0, // And this one
+          }),
+        })
+      );
+      expect(logAudit).toHaveBeenCalledWith("CREATE", expect.any(Object));
+    });
   });
 
   describe('updateIOMStatus', () => {

--- a/src/lib/iom.ts
+++ b/src/lib/iom.ts
@@ -141,7 +141,7 @@ type CreateIomData = z.infer<typeof createIomSchema> & {
 export async function createIOM(data: CreateIomData, session: Session) {
   authorize(session, 'CREATE_IOM');
   const { items, reviewerId, approverId, status, ...actualRest } = data;
-  const totalAmount = items.reduce((sum, item) => sum + (item.quantity * item.unitPrice), 0);
+  const totalAmount = (items || []).reduce((sum, item) => sum + (item.quantity * item.unitPrice), 0);
 
   const maxRetries = 3;
   let lastError: unknown;
@@ -156,7 +156,7 @@ export async function createIOM(data: CreateIomData, session: Session) {
       approvedById: approverId,
       status: status === 'DRAFT' ? IOMStatus.DRAFT : IOMStatus.PENDING_APPROVAL,
       items: {
-        create: items.map(item => ({
+        create: (items || []).map(item => ({
           ...item,
           totalPrice: item.quantity * item.unitPrice,
         })),


### PR DESCRIPTION
This commit fixes a build error that occurred after making the `items` array optional in the IOM creation schema.

The `createIOM` function in `src/lib/iom.ts` was not correctly handling cases where the `items` array was `undefined`, leading to a `TypeError` when calling `.reduce()` and `.map()`.

The fix involves providing a default empty array `[]` when accessing the `items` property, ensuring the function works correctly for both IOMs with and without items.

A regression test has also been added to `src/lib/iom.test.ts` to specifically cover the creation of an IOM without an items array, preventing this issue from recurring.