### PR TITLE
feat(iom): Make item section optional and fix build errors

### DIFF
--- a/src/lib/iom.test.ts
+++ b/src/lib/iom.test.ts
@@ -102,6 +102,7 @@ describe('IOM Functions', () => {
       vi.mocked(prisma.iOM.create).mockResolvedValue(createdIomMock);
 
       // We need to cast because the base type expects `items`
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await createIOM(iomData as any, session);
 
       expect(authorize).toHaveBeenCalledWith(session, 'CREATE_IOM');


### PR DESCRIPTION
This commit introduces the feature to allow creating Internal Office Memos (IOMs) without an item section, catering to general-purpose memos.

It also includes fixes for a subsequent build failure and a linting error that were discovered during implementation.

Key changes:
- The backend validation schema (`src/lib/schemas.ts`) now allows the `items` array to be optional.
- The IOM creation form (`src/app/iom/create/page.tsx`) is updated to conditionally render the items section.
- The `createIOM` function in `src/lib/iom.ts` now safely handles cases where `items` is `undefined`.
- A regression test has been added to `src/lib/iom.test.ts` to cover creating an IOM without items.
- A linting error in the new test case has been suppressed with an `eslint-disable-next-line` comment.