### PR TITLE
Fix(print): Correct IOM print view layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -147,7 +147,6 @@
     /* Use flexbox for layout */
     display: flex;
     flex-direction: column;
-    min-height: 98vh; /* Use vh to approximate page height, leaving a small margin */
   }
 
   /* Allow the main content to expand and push the footer down */
@@ -158,31 +157,5 @@
   /* Ensure the footer doesn't shrink */
   .iom-footer {
     flex-shrink: 0;
-  }
-
-  /* More specific print styles for the IOM view */
-  body * {
-    visibility: hidden;
-  }
-  #iom-print-view, #iom-print-view * {
-    visibility: visible;
-  }
-  #iom-print-view {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: auto;
-    box-shadow: none !important;
-    padding: 0 !important;
-    margin: 0 !important;
-    border: none !important;
-  }
-  .iom-footer {
-    position: fixed;
-    bottom: 2rem;
-    left: 0;
-    right: 0;
-    width: 100%;
   }
 }


### PR DESCRIPTION
This commit fixes two issues with the IOM print view:
1. An extra, empty second page was being generated.
2. The signature section at the bottom was not visible.

The root cause was conflicting and incorrect CSS rules within two separate `@media print` blocks in `src/app/globals.css`.

- The extra page was caused by a `min-height: 98vh` rule on the main print container, which forced it to a full-page height.
- The invisible signature footer was caused by a `position: fixed` rule, which is often problematic in print contexts.

The solution is to consolidate the print styles into a single, correct `@media print` block. This change removes the problematic `min-height` and `position: fixed` rules, and uses a flexbox-based layout to ensure the footer correctly appears at the bottom of the content. This resolves both issues.