### PR TITLE
Fix(print): Correct IOM print view layout (2nd attempt)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -123,6 +123,13 @@
 
 /* Add print styles at the end */
 @media print {
+  /* Resetting default margin and padding */
+  body, html {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+  }
+
   /* Hide everything by default */
   body * {
     visibility: hidden;
@@ -133,29 +140,28 @@
     visibility: visible;
   }
 
-  /* Position the printable area to take up the whole page */
+  /* Use a robust flexbox layout for the print view */
   #iom-print-view {
-    position: absolute;
-    left: 0;
-    top: 0;
+    position: static; /* Use static positioning */
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh; /* Use vh for full page height */
     width: 100%;
-    padding: 0 !important;
+    padding: 2rem !important; /* Add some padding */
     margin: 0 !important;
     border: none !important;
     box-shadow: none !important;
-
-    /* Use flexbox for layout */
-    display: flex;
-    flex-direction: column;
+    box-sizing: border-box; /* Ensure padding is included in height */
   }
 
-  /* Allow the main content to expand and push the footer down */
+  /* Allow the main content to expand */
   .iom-main-content {
     flex-grow: 1;
   }
 
-  /* Ensure the footer doesn't shrink */
+  /* Push the footer to the bottom */
   .iom-footer {
     flex-shrink: 0;
+    margin-top: auto !important;
   }
 }


### PR DESCRIPTION
This commit fixes two issues with the IOM print view:
1. An extra, empty second page was being generated.
2. The signature section at the bottom was not visible or was not positioned correctly at the bottom of the page.

This new approach uses a more robust flexbox-based layout for the print view.

- The print container (`#iom-print-view`) is set to a `min-height` of `100vh` to ensure it fills the entire page.
- The main content area is set to `flex-grow: 1` to take up any available space.
- The footer (`iom-footer`) is pushed to the bottom of the container using `margin-top: auto`.

This combination ensures that for short documents, the footer is correctly positioned at the bottom of the page, and for long documents, it flows naturally at the end of the content, preventing unnecessary blank pages.