### PR TITLE
Fix(print): Correct IOM print view layout (3rd attempt)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -121,47 +121,42 @@
   }
 }
 
-/* Add print styles at the end */
 @media print {
-  /* Resetting default margin and padding */
-  body, html {
+  html, body {
+    height: 100%;
     margin: 0;
     padding: 0;
-    height: 100%;
   }
 
-  /* Hide everything by default */
   body * {
     visibility: hidden;
   }
 
-  /* Make only the printable area and its children visible */
-  #iom-print-view, #iom-print-view * {
+  #iom-print-view,
+  #iom-print-view * {
     visibility: visible;
   }
 
-  /* Use a robust flexbox layout for the print view */
   #iom-print-view {
-    position: static; /* Use static positioning */
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
     display: flex;
     flex-direction: column;
-    min-height: 100vh; /* Use vh for full page height */
-    width: 100%;
-    padding: 2rem !important; /* Add some padding */
-    margin: 0 !important;
-    border: none !important;
-    box-shadow: none !important;
-    box-sizing: border-box; /* Ensure padding is included in height */
+    padding: 2rem !important;
+    box-sizing: border-box;
+    -webkit-print-color-adjust: exact; /* Chrome, Safari */
+    color-adjust: exact; /* Firefox */
   }
 
-  /* Allow the main content to expand */
   .iom-main-content {
     flex-grow: 1;
   }
 
-  /* Push the footer to the bottom */
   .iom-footer {
     flex-shrink: 0;
-    margin-top: auto !important;
+    margin-top: auto;
   }
 }


### PR DESCRIPTION
This commit provides a definitive fix for the IOM print view issues, including extra blank pages and incorrect footer positioning.

The root cause was a combination of issues with how the browser was handling the print layout, caused by the application's CSS.

This final solution uses the following robust strategy:
1.  It uses `visibility: hidden` to hide all elements on the page.
2.  It uses `visibility: visible` to show only the `#iom-print-view` container and its contents. This is the correct way to isolate a component for printing, as `display: none` on a parent would hide the children unconditionally.
3.  It takes the `#iom-print-view` container out of the normal document flow using `position: absolute` and makes it cover the entire page (`top: 0, left: 0, width: 100%, height: 100%`). This prevents other (now invisible) elements from pushing it onto a second page.
4.  It uses a flexbox layout within the full-height print container to correctly position the main content and push the footer to the bottom of the page, regardless of content length.

This combination of techniques should resolve all reported printing issues.