### PR TITLE
Fix(print): Correct IOM print view layout (4th attempt)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -149,6 +149,8 @@
     box-sizing: border-box;
     -webkit-print-color-adjust: exact; /* Chrome, Safari */
     color-adjust: exact; /* Firefox */
+    box-shadow: none !important;
+    border: none !important;
   }
 
   .iom-main-content {


### PR DESCRIPTION
This commit provides the definitive fix for the IOM print view issues. The remaining issue of a second blank page with a shadow element is resolved.

The root cause of the final issue was a `box-shadow` style on the print view container that was not being disabled during printing. This shadow was enough to cause the browser's print layout engine to create an extra page.

This commit adds `box-shadow: none !important;` and `border: none !important;` to the `#iom-print-view` print styles to ensure no part of the component's decoration causes page overflow.

This is the culmination of several attempts and should now result in a clean, single-page printout with the footer correctly positioned.