### PR TITLE
Fix(print): Use targeted display:none for clean print layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -122,43 +122,27 @@
 }
 
 @media print {
-  html, body {
-    height: 100%;
-    margin: 0;
-    padding: 0;
+  /* Hide the main header and the IOM page's sidebar */
+  header.bg-white,
+  [class~="lg:col-span-2"] + .space-y-6 {
+    display: none !important;
   }
 
-  body * {
-    visibility: hidden;
+  /* Remove padding and other layout styles from the main layout containers */
+  .max-w-7xl,
+  .px-4.py-6,
+  .min-h-screen {
+    padding: 0 !important;
+    margin: 0 !important;
+    max-width: none !important;
+    min-height: 0 !important;
   }
 
-  #iom-print-view,
-  #iom-print-view * {
-    visibility: visible;
-  }
-
+  /* Ensure the print view itself has no extra layout styling */
   #iom-print-view {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    padding: 2rem !important;
-    box-sizing: border-box;
-    -webkit-print-color-adjust: exact; /* Chrome, Safari */
-    color-adjust: exact; /* Firefox */
+    padding: 0 !important;
+    margin: 0 !important;
     box-shadow: none !important;
     border: none !important;
-  }
-
-  .iom-main-content {
-    flex-grow: 1;
-  }
-
-  .iom-footer {
-    flex-shrink: 0;
-    margin-top: auto;
   }
 }


### PR DESCRIPTION
This commit implements a new strategy to fix the persistent printing issues with the IOM view. Previous attempts using flexbox sticky footers and visibility toggling were unsuccessful and caused extra blank pages.

This new, more direct approach abandons the sticky footer for print and instead focuses on cleanly removing all non-essential elements from the printed page.

The fix involves:
1.  Using `display: none !important;` to specifically target and hide the page's main header and the IOM view's sidebar. A robust attribute selector `[class~="..."]` is used to avoid build errors with special characters in class names.
2.  Removing all padding, margin, and min-height from the parent layout containers to prevent them from adding any extra space to the printed output.
3.  Resetting the `IOMPrintView` component's own padding, margin, and shadow to ensure it is a clean, unstyled block.

This results in a print view that contains only the IOM content, flowing naturally on the page. This should definitively resolve the blank page issue.