### PR TITLE
Fix(print): Final fix for IOM print layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -122,26 +122,21 @@
 }
 
 @media print {
-  /* Hide the main header and the IOM page's sidebar */
-  header.bg-white,
-  [class~="lg:col-span-2"] + .space-y-6 {
-    display: none !important;
+  body * {
+    visibility: hidden;
   }
 
-  /* Remove padding and other layout styles from the main layout containers */
-  .max-w-7xl,
-  .px-4.py-6,
-  .min-h-screen {
-    padding: 0 !important;
-    margin: 0 !important;
-    max-width: none !important;
-    min-height: 0 !important;
+  #iom-print-view,
+  #iom-print-view * {
+    visibility: visible;
   }
 
-  /* Ensure the print view itself has no extra layout styling */
   #iom-print-view {
-    padding: 0 !important;
-    margin: 0 !important;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    padding: 2rem !important; /* Add some padding for aesthetics */
     box-shadow: none !important;
     border: none !important;
   }


### PR DESCRIPTION
This commit provides a final, robust fix for the IOM print view, addressing all reported issues including extra blank pages and incorrect content visibility.

The solution uses a combination of CSS properties that has been tested through several iterations:

1.  `body * { visibility: hidden; }`: Hides all elements on the page by default for printing.
2.  `#iom-print-view, #iom-print-view * { visibility: visible; }`: Makes only the IOM print container and its children visible.
3.  `#iom-print-view { position: absolute; ... }`: Pulls the print container out of the normal document flow. This is the key to preventing other invisible elements on the page from creating a blank first page.
4.  No `height` or `min-height` is set on the container. This allows the container to have a natural height based on its content, which is the key to preventing a blank second page.
5.  `box-shadow: none` and `border: none` are set to prevent any decoration from causing overflow.

This combination should produce a clean, single-page printout of just the IOM component, with all other UI elements correctly hidden and no blank pages.