### PR TITLE
Feat(print): Implement print views for PO and PR modules

### DIFF
--- a/src/components/POPrintView.tsx
+++ b/src/components/POPrintView.tsx
@@ -1,0 +1,104 @@
+import { PurchaseOrder } from "@/types/po";
+import { formatCurrency } from "@/lib/utils";
+
+interface POPrintViewProps {
+  po: PurchaseOrder;
+}
+
+export default function POPrintView({ po }: POPrintViewProps) {
+  return (
+    <div className="bg-white shadow-lg p-8 md:p-12" id="po-print-view">
+      {/* Header */}
+      <header className="text-center mb-8">
+        <img src="/logo.png" alt="Company Logo" className="mx-auto h-12 w-auto mb-4" />
+        <h1 className="text-2xl font-bold text-gray-800">{po.companyName}</h1>
+        <p className="text-xs text-gray-600 whitespace-pre-wrap">{po.companyAddress}</p>
+        <p className="text-xs text-gray-600">{po.companyContact}</p>
+      </header>
+
+      {/* Title */}
+      <div className="text-center my-8">
+        <h2 className="text-lg font-bold underline uppercase tracking-wider">
+          Purchase Order
+        </h2>
+      </div>
+
+      {/* Meta Info */}
+      <div className="grid grid-cols-2 gap-x-12 mb-8 text-sm">
+        <div className="border border-gray-300 p-4 rounded-lg">
+          <h3 className="font-bold mb-2">Vendor</h3>
+          <p>{po.vendorName}</p>
+          <p className="whitespace-pre-wrap">{po.vendorAddress}</p>
+          <p>{po.vendorContact}</p>
+        </div>
+        <div className="text-right">
+          <p><span className="font-bold">PO #:</span> {po.poNumber}</p>
+          <p><span className="font-bold">Date:</span> {new Date(po.createdAt!).toLocaleDateString()}</p>
+          {po.iom && <p><span className="font-bold">IOM Ref:</span> {po.iom.iomNumber}</p>}
+        </div>
+      </div>
+
+      {/* Items Table */}
+      <section className="mb-8 po-main-content">
+        <table className="w-full border-collapse border border-gray-400 text-sm">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="border border-gray-300 p-2 text-left">S.No</th>
+              <th className="border border-gray-300 p-2 text-left">Description</th>
+              <th className="border border-gray-300 p-2 text-center">Qty</th>
+              <th className="border border-gray-300 p-2 text-right">Unit Price</th>
+              <th className="border border-gray-300 p-2 text-right">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {po.items.map((item, index) => (
+              <tr key={index}>
+                <td className="border border-gray-300 p-2">{index + 1}</td>
+                <td className="border border-gray-300 p-2">{item.itemName} - {item.description}</td>
+                <td className="border border-gray-300 p-2 text-center">{item.quantity}</td>
+                <td className="border border-gray-300 p-2 text-right">{formatCurrency(item.unitPrice)}</td>
+                <td className="border border-gray-300 p-2 text-right">{formatCurrency(item.totalPrice)}</td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot className="font-bold">
+            <tr>
+              <td colSpan={4} className="border border-gray-300 p-2 text-right">Subtotal</td>
+              <td className="border border-gray-300 p-2 text-right">{formatCurrency(po.totalAmount)}</td>
+            </tr>
+            <tr>
+              <td colSpan={4} className="border border-gray-300 p-2 text-right">Tax ({po.taxRate}%)</td>
+              <td className="border border-gray-300 p-2 text-right">{formatCurrency(po.taxAmount)}</td>
+            </tr>
+            <tr>
+              <td colSpan={4} className="border border-gray-300 p-2 text-right text-lg">Grand Total</td>
+              <td className="border border-gray-300 p-2 text-right text-lg">{formatCurrency(po.grandTotal)}</td>
+            </tr>
+          </tfoot>
+        </table>
+      </section>
+
+      {/* Footer Signatures */}
+      <footer className="mt-24 pt-8 po-footer">
+        <div className="grid grid-cols-4 gap-4 text-center text-xs">
+          <div>
+            <p className="font-bold border-t border-gray-400 pt-2">Prepared By</p>
+            <p className="mt-8">{po.preparedBy?.name || 'N/A'}</p>
+          </div>
+          <div>
+            <p className="font-bold border-t border-gray-400 pt-2">Requested By</p>
+            <p className="mt-8">{po.requestedBy?.name || 'N/A'}</p>
+          </div>
+          <div>
+            <p className="font-bold border-t border-gray-400 pt-2">Reviewed By</p>
+            <p className="mt-8">{po.reviewedBy?.name || 'N/A'}</p>
+          </div>
+          <div>
+            <p className="font-bold border-t border-gray-400 pt-2">Authorized By</p>
+            <p className="mt-8">{po.approvedBy?.name || 'N/A'}</p>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/components/PRPrintView.tsx
+++ b/src/components/PRPrintView.tsx
@@ -1,0 +1,111 @@
+import { PaymentRequest, PaymentMethod } from "@/types/pr";
+import { UserRef } from "@/types/iom";
+import { PurchaseOrder } from "@prisma/client";
+import { formatCurrency } from "@/lib/utils";
+
+// Copied from PR Detail Page
+type FullPaymentRequest = PaymentRequest & {
+  po?: Partial<PurchaseOrder> | null;
+  preparedBy?: UserRef | null;
+  requestedBy?: UserRef | null;
+  reviewedBy?: UserRef | null;
+  approvedBy?: UserRef | null;
+};
+
+interface PRPrintViewProps {
+  pr: FullPaymentRequest;
+}
+
+const getPaymentMethodLabel = (method: PaymentMethod) => {
+  switch (method) {
+    case PaymentMethod.CHEQUE: return "Cheque";
+    case PaymentMethod.BANK_TRANSFER: return "Bank Transfer";
+    case PaymentMethod.CASH: return "Cash";
+    case PaymentMethod.ONLINE_PAYMENT: return "Online Payment";
+    default: return method;
+  }
+};
+
+export default function PRPrintView({ pr }: PRPrintViewProps) {
+  return (
+    <div className="bg-white shadow-lg p-8 md:p-12" id="pr-print-view">
+      {/* Header */}
+      <header className="text-center mb-8">
+        <img src="/logo.png" alt="Company Logo" className="mx-auto h-12 w-auto mb-4" />
+        <h1 className="text-2xl font-bold text-gray-800">Sri Bhagyalakshmi Enterprises</h1>
+        {/* Company address can be fetched from a settings API if needed */}
+      </header>
+
+      {/* Title */}
+      <div className="text-center my-8">
+        <h2 className="text-lg font-bold underline uppercase tracking-wider">
+          Payment Request
+        </h2>
+      </div>
+
+      {/* Meta Info */}
+      <div className="flex justify-between items-start mb-6 text-sm">
+        <div>
+          <p><span className="font-bold">PR #:</span> {pr.prNumber}</p>
+          {pr.po && <p><span className="font-bold">Linked PO:</span> {pr.po.poNumber}</p>}
+          <p><span className="font-bold">Payment To:</span> {pr.paymentTo}</p>
+        </div>
+        <div>
+          <p><span className="font-bold">Date:</span> {new Date(pr.createdAt!).toLocaleDateString()}</p>
+          <p><span className="font-bold">Payment Date:</span> {new Date(pr.paymentDate).toLocaleDateString()}</p>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <main className="pr-main-content space-y-6">
+        {/* Payment Details */}
+        <div className="border border-gray-300 p-4 rounded-lg">
+          <h3 className="text-lg font-medium text-gray-900 mb-3">Payment Details</h3>
+          <dl className="grid grid-cols-2 gap-4 text-sm">
+            <div><dt className="font-bold">Payment Method</dt><dd>{getPaymentMethodLabel(pr.paymentMethod)}</dd></div>
+            {pr.bankAccount && <div><dt className="font-bold">Bank Account</dt><dd>{pr.bankAccount}</dd></div>}
+            {pr.referenceNumber && <div><dt className="font-bold">Reference Number</dt><dd>{pr.referenceNumber}</dd></div>}
+          </dl>
+        </div>
+
+        {/* Purpose */}
+        <div className="border border-gray-300 p-4 rounded-lg">
+          <h3 className="text-lg font-medium text-gray-900 mb-3">Purpose</h3>
+          <p className="text-sm text-gray-900 whitespace-pre-wrap">{pr.purpose}</p>
+        </div>
+
+        {/* Financial Summary */}
+        <div className="border border-gray-300 p-4 rounded-lg">
+          <h3 className="text-lg font-medium text-gray-900 mb-3">Financial Summary</h3>
+          <dl className="space-y-2 text-sm">
+            <div className="flex justify-between"><dt>Total Amount</dt><dd>{formatCurrency(pr.totalAmount)}</dd></div>
+            <div className="flex justify-between"><dt>Tax Amount</dt><dd>{formatCurrency(pr.taxAmount)}</dd></div>
+            <div className="flex justify-between border-t pt-2 mt-2 font-bold text-base"><dt>Grand Total</dt><dd>{formatCurrency(pr.grandTotal)}</dd></div>
+          </dl>
+        </div>
+      </main>
+
+      {/* Footer Signatures */}
+      <footer className="mt-24 pt-8 pr-footer">
+        <div className="grid grid-cols-4 gap-4 text-center text-xs">
+          <div>
+            <p className="font-bold border-t border-gray-400 pt-2">Prepared By</p>
+            <p className="mt-8">{pr.preparedBy?.name || 'N/A'}</p>
+          </div>
+          <div>
+            <p className="font-bold border-t border-gray-400 pt-2">Requested By</p>
+            <p className="mt-8">{pr.requestedBy?.name || 'N/A'}</p>
+          </div>
+          <div>
+            <p className="font-bold border-t border-gray-400 pt-2">Reviewed By</p>
+            <p className="mt-8">{pr.reviewedBy?.name || 'N/A'}</p>
+          </div>
+          <div>
+            <p className="font-bold border-t border-gray-400 pt-2">Authorized By</p>
+            <p className="mt-8">{pr.approvedBy?.name || 'N/A'}</p>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
This commit adds a robust, iframe-based printing solution to the Purchase Order (PO) and Payment Request (PR) modules, replicating the functionality recently added to the IOM module.

This addresses the user's request to have a consistent, clean, and reliable printing experience across all document types.

Key changes:
- Created new `POPrintView.tsx` and `PRPrintView.tsx` components to provide dedicated, print-friendly layouts for POs and PRs.
- Refactored the PO and PR detail pages to use these new components.
- Implemented a `handlePrint` function on both detail pages that uses a hidden iframe to print the document. This isolates the print content from the main application's layout, ensuring a perfect print with a correctly positioned sticky footer and no blank pages.
- Removed all old `@media print` styles from `globals.css` as they are now obsolete.
- Fixed a type import error in `PRPrintView.tsx` that was causing a build failure.