### PR TITLE
Fix(print): Adjust print view headers and footers

### DIFF
--- a/src/components/IOMPrintView.tsx
+++ b/src/components/IOMPrintView.tsx
@@ -125,14 +125,10 @@ export default function IOMPrintView({ iom }: IOMPrintViewProps) {
 
       {/* Footer Signatures */}
       <footer className="mt-24 pt-8 iom-footer">
-        <div className="grid grid-cols-4 gap-4 text-center text-xs">
+        <div className="grid grid-cols-3 gap-4 text-center text-xs">
           <div>
             <p className="font-bold border-t border-gray-400 pt-2">Prepared By</p>
             <p className="mt-8">{iom.preparedBy?.name || 'N/A'}</p>
-          </div>
-          <div>
-            <p className="font-bold border-t border-gray-400 pt-2">Requested By</p>
-            <p className="mt-8">{iom.requestedBy?.name || 'N/A'}</p>
           </div>
           <div>
             <p className="font-bold border-t border-gray-400 pt-2">Reviewed By</p>


### PR DESCRIPTION
This commit applies final adjustments to the new print views for IOM, PO, and PR based on user feedback.

Changes:
- The `POPrintView` and `PRPrintView` components now dynamically fetch and display the company header information, ensuring a consistent header across all printable documents.
- The "Requested By" field has been removed from the signature footer in all three print view components (`IOMPrintView`, `POPrintView`, `PRPrintView`) as requested.
- The footer layout grid has been adjusted from 4 columns to 3 to maintain even spacing.