### PR TITLE
feat: Add public API endpoints for QR code scanning

### DIFF
--- a/src/app/api/iom/public/[id]/route.ts
+++ b/src/app/api/iom/public/[id]/route.ts
@@ -1,0 +1,26 @@
+// src/app/api/iom/public/[id]/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { getIOMById } from "@/lib/iom";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ id:string }> }
+) {
+  const { id } = await context.params;
+
+  try {
+    const iom = await getIOMById(id);
+
+    if (!iom) {
+      return NextResponse.json({ error: "IOM not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(iom);
+  } catch (error) {
+    console.error("Error fetching IOM:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/po/public/[id]/route.ts
+++ b/src/app/api/po/public/[id]/route.ts
@@ -1,0 +1,26 @@
+// src/app/api/po/public/[id]/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { getPOById } from "@/lib/po";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id } = await context.params;
+
+  try {
+    const po = await getPOById(id);
+
+    if (!po) {
+      return NextResponse.json({ error: "PO not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(po);
+  } catch (error) {
+    console.error("Error fetching PO:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/pr/public/[id]/route.ts
+++ b/src/app/api/pr/public/[id]/route.ts
@@ -1,0 +1,26 @@
+// src/app/api/pr/public/[id]/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { getPRById } from "@/lib/pr";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id } = await context.params;
+
+  try {
+    const pr = await getPRById(id);
+
+    if (!pr) {
+      return NextResponse.json({ error: "PR not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(pr);
+  } catch (error) {
+    console.error("Error fetching PR:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/print/iom/[id]/page.tsx
+++ b/src/app/print/iom/[id]/page.tsx
@@ -16,7 +16,7 @@ export default function IOMPrintPage() {
   const fetchIOM = useCallback(async () => {
     setLoading(true);
     try {
-      const response = await fetch(`/api/iom/${params.id}`);
+      const response = await fetch(`/api/iom/public/${params.id}`);
       if (response.ok) {
         const data = await response.json();
         setIom(data);

--- a/src/app/print/po/[id]/page.tsx
+++ b/src/app/print/po/[id]/page.tsx
@@ -15,7 +15,7 @@ export default function POPrintPage() {
   const fetchPO = useCallback(async () => {
     setLoading(true);
     try {
-      const response = await fetch(`/api/po/${params.id}`);
+      const response = await fetch(`/api/po/public/${params.id}`);
       if (response.ok) {
         const data = await response.json();
         setPo(data);

--- a/src/app/print/pr/[id]/page.tsx
+++ b/src/app/print/pr/[id]/page.tsx
@@ -25,7 +25,7 @@ export default function PRPrintPage() {
   const fetchPR = useCallback(async () => {
     setLoading(true);
     try {
-      const response = await fetch(`/api/pr/${params.id}`);
+      const response = await fetch(`/api/pr/public/${params.id}`);
       if (response.ok) {
         const data = await response.json();
         setPr(data);


### PR DESCRIPTION
This change introduces new public API endpoints for Purchase Orders (POs), Inter-Office Memorandums (IOMs), and Purchase Requests (PRs) to allow unauthenticated access to the document data. This is necessary for the QR code scanning feature to work correctly, as users scanning the QR code will not be logged in.

The following changes were made:
- Created public API routes at `/api/po/public/[id]`, `/api/iom/public/[id]`, and `/api/pr/public/[id]`.
- Updated the corresponding print pages at `/print/po/[id]`, `/print/iom/[id]`, and `/print/pr/[id]` to use these new public routes.

This resolves the "PO Not Found", "IOM Not Found", and "PR Not Found" errors that were occurring when scanning QR codes.