### PR TITLE
fix: Ensure QR code generation and PDF access for all documents

### DIFF
--- a/src/app/api/iom/public/[id]/route.ts
+++ b/src/app/api/iom/public/[id]/route.ts
@@ -1,6 +1,6 @@
 // src/app/api/iom/public/[id]/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { getIOMById } from "@/lib/iom";
+import { getPublicIOMById } from "@/lib/iom";
 
 export async function GET(
   request: NextRequest,
@@ -9,7 +9,7 @@ export async function GET(
   const { id } = await context.params;
 
   try {
-    const iom = await getIOMById(id);
+    const iom = await getPublicIOMById(id);
 
     if (!iom) {
       return NextResponse.json({ error: "IOM not found" }, { status: 404 });

--- a/src/app/api/po/public/[id]/route.ts
+++ b/src/app/api/po/public/[id]/route.ts
@@ -1,6 +1,6 @@
 // src/app/api/po/public/[id]/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { getPOById } from "@/lib/po";
+import { getPublicPOById } from "@/lib/po";
 
 export async function GET(
   request: NextRequest,
@@ -9,7 +9,7 @@ export async function GET(
   const { id } = await context.params;
 
   try {
-    const po = await getPOById(id);
+    const po = await getPublicPOById(id);
 
     if (!po) {
       return NextResponse.json({ error: "PO not found" }, { status: 404 });

--- a/src/app/api/pr/public/[id]/route.ts
+++ b/src/app/api/pr/public/[id]/route.ts
@@ -1,6 +1,6 @@
 // src/app/api/pr/public/[id]/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { getPRById } from "@/lib/pr";
+import { getPublicPRById } from "@/lib/pr";
 
 export async function GET(
   request: NextRequest,
@@ -9,7 +9,7 @@ export async function GET(
   const { id } = await context.params;
 
   try {
-    const pr = await getPRById(id);
+    const pr = await getPublicPRById(id);
 
     if (!pr) {
       return NextResponse.json({ error: "PR not found" }, { status: 404 });


### PR DESCRIPTION
This commit resolves a multi-faceted issue where QR codes were not appearing on print previews for older documents and scanning a QR code resulted in a "Not Found" error in the generated PDF.

The root causes were:
1. Older documents were missing a `pdfToken`, which is required to render the QR code.
2. The print pages were attempting to fetch data from protected API endpoints, which failed when accessed by the unauthenticated PDF generation service.
3. The `NEXT_PUBLIC_APP_URL` environment variable was not set, preventing the correct URLs from being generated for the QR codes and the PDF service.

This has been resolved by:
- Updating the public data-fetching functions (`getPublicPOById`, `getPublicIOMById`, `getPublicPRById`) to automatically generate and save a `pdfToken` for any document that is missing one.
- Creating public, unauthenticated API endpoints for the print pages to fetch data from.
- Adding a `.env.local` file to define the `NEXT_PUBLIC_APP_URL`.

This ensures that all documents, new and old, will have a QR code that can be successfully scanned to download the correct PDF.