### PR TITLE
fix: Ensure QR code generation and visibility in print preview

### DIFF
--- a/src/components/IOMPrintView.tsx
+++ b/src/components/IOMPrintView.tsx
@@ -17,6 +17,7 @@ interface IOMPrintViewProps {
 export default function IOMPrintView({ iom }: IOMPrintViewProps) {
   const [headerText, setHeaderText] = useState("");
   const [loadingHeader, setLoadingHeader] = useState(true);
+  const [isPrinting, setIsPrinting] = useState(false);
 
   useEffect(() => {
     const fetchHeaderSetting = async () => {
@@ -39,6 +40,13 @@ export default function IOMPrintView({ iom }: IOMPrintViewProps) {
 
     fetchHeaderSetting();
   }, []);
+
+  useEffect(() => {
+    if (!loadingHeader && !isPrinting) {
+      setIsPrinting(true);
+      setTimeout(() => window.print(), 500); // Small delay to ensure QR code renders
+    }
+  }, [loadingHeader, isPrinting]);
 
   const hasItems = iom.items && iom.items.length > 0;
 

--- a/src/components/POPrintView.tsx
+++ b/src/components/POPrintView.tsx
@@ -16,6 +16,7 @@ interface Setting {
 export default function POPrintView({ po }: POPrintViewProps) {
   const [headerText, setHeaderText] = useState("");
   const [loadingHeader, setLoadingHeader] = useState(true);
+  const [isPrinting, setIsPrinting] = useState(false);
 
   useEffect(() => {
     const fetchHeaderSetting = async () => {
@@ -37,6 +38,13 @@ export default function POPrintView({ po }: POPrintViewProps) {
 
     fetchHeaderSetting();
   }, []);
+
+  useEffect(() => {
+    if (!loadingHeader && !isPrinting) {
+      setIsPrinting(true);
+      setTimeout(() => window.print(), 500); // Small delay to ensure QR code renders
+    }
+  }, [loadingHeader, isPrinting]);
 
   return (
     <div className="bg-white shadow-lg p-8 md:p-12" id="po-print-view">

--- a/src/components/PRPrintView.tsx
+++ b/src/components/PRPrintView.tsx
@@ -37,6 +37,7 @@ const getPaymentMethodLabel = (method: PaymentMethod) => {
 export default function PRPrintView({ pr }: PRPrintViewProps) {
   const [headerText, setHeaderText] = useState("");
   const [loadingHeader, setLoadingHeader] = useState(true);
+  const [isPrinting, setIsPrinting] = useState(false);
 
   useEffect(() => {
     const fetchHeaderSetting = async () => {
@@ -58,6 +59,13 @@ export default function PRPrintView({ pr }: PRPrintViewProps) {
 
     fetchHeaderSetting();
   }, []);
+
+  useEffect(() => {
+    if (!loadingHeader && !isPrinting) {
+      setIsPrinting(true);
+      setTimeout(() => window.print(), 500); // Small delay to ensure QR code renders
+    }
+  }, [loadingHeader, isPrinting]);
 
   return (
     <div className="bg-white shadow-lg p-8 md:p-12" id="pr-print-view">


### PR DESCRIPTION
This commit resolves a multi-faceted issue where QR codes were not appearing on print previews for older documents and scanning a QR code resulted in a "Not Found" error in the generated PDF.

The root causes were:
1. A timing issue where the print dialog was opened before the QR code component could render.
2. Older documents were missing a `pdfToken`, which is required to render the QR code.
3. The print pages were attempting to fetch data from protected API endpoints, which failed when accessed by the unauthenticated PDF generation service.
4. The `NEXT_PUBLIC_APP_URL` environment variable was not set, preventing the correct URLs from being generated.

This has been resolved by:
- Modifying the print view components (`POPrintView`, `IOMPrintView`, `PRPrintView`) to trigger the print dialog via a `useEffect` hook, ensuring all content is rendered first.
- Updating the public data-fetching functions to automatically generate and save a `pdfToken` for any document that is missing one.
- Creating public, unauthenticated API endpoints for the print pages to fetch data from.
- Adding a `.env.local` file to define the `NEXT_PUBLIC_APP_URL`.

This ensures that all documents, new and old, will have a QR code that is visible in the print preview and can be successfully scanned to download the correct PDF.