### PR TITLE
feat: Modernize UI and enhance print views

### DIFF
--- a/src/app/iom/[id]/page.tsx
+++ b/src/app/iom/[id]/page.tsx
@@ -186,19 +186,19 @@ export default function IOMDetailPage() {
 
   return (
     <PageLayout title={iom.title}>
-      <div className="mb-6">
-        <Link href="/iom" className="text-blue-600 hover:text-blue-800">
-          &larr; Back to IOM List
-        </Link>
-      </div>
       <div className="flex justify-between items-start mt-2 mb-6">
         <div>
           <p className="text-lg text-gray-600">{iom.iomNumber}</p>
         </div>
         <div className="text-right">
-          <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getIOMStatusColor(iom.status)}`}>
-            {iom.status.replace("_", " ")}
-          </span>
+          <Link href="/iom" className="text-sm font-medium text-blue-600 hover:text-blue-800 inline-block mb-2">
+            &larr; Back to IOM List
+          </Link>
+          <div>
+            <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getIOMStatusColor(iom.status)}`}>
+              {iom.status.replace("_", " ")}
+            </span>
+          </div>
           <p className="text-sm text-gray-500 mt-1">
             Created: {new Date(iom.createdAt!).toLocaleDateString()}
           </p>

--- a/src/app/po/[id]/page.tsx
+++ b/src/app/po/[id]/page.tsx
@@ -225,11 +225,6 @@ export default function PODetailPage() {
 
   return (
     <PageLayout title={po.title}>
-      <div className="mb-6">
-        <Link href="/po" className="text-blue-600 hover:text-blue-800">
-          &larr; Back to PO List
-        </Link>
-      </div>
       <div className="flex justify-between items-start mt-2 mb-6">
         <div>
           <p className="text-lg text-gray-600">{po.poNumber}</p>
@@ -240,9 +235,14 @@ export default function PODetailPage() {
           )}
         </div>
         <div className="text-right">
-          <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getPOStatusColor(po.status)}`}>
-            {po.status.replace("_", " ")}
-          </span>
+          <Link href="/po" className="text-sm font-medium text-blue-600 hover:text-blue-800 inline-block mb-2">
+            &larr; Back to PO List
+          </Link>
+          <div>
+            <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getPOStatusColor(po.status)}`}>
+              {po.status.replace("_", " ")}
+            </span>
+          </div>
           <p className="text-sm text-gray-500 mt-1">
                 Created: {new Date(po.createdAt!).toLocaleDateString()}
               </p>

--- a/src/app/pr/[id]/page.tsx
+++ b/src/app/pr/[id]/page.tsx
@@ -16,7 +16,9 @@ import { useHasPermission } from "@/hooks/useHasPermission";
 import PRPrintView from "@/components/PRPrintView";
 
 type FullPaymentRequest = PaymentRequest & {
-  po?: Partial<PurchaseOrder> | null;
+  po?: (Partial<PurchaseOrder> & {
+    iom?: { iomNumber: string } | null;
+  }) | null;
   preparedBy?: UserRef | null;
   requestedBy?: UserRef | null;
   reviewedBy?: UserRef | null;
@@ -191,14 +193,19 @@ export default function PRDetailPage() {
 
   return (
     <PageLayout title={pr.title}>
-      <div className="mb-6"><Link href="/pr" className="text-blue-600 hover:text-blue-800">&larr; Back to PR List</Link></div>
       <div className="flex justify-between items-start mt-2 mb-6">
         <div>
           <p className="text-lg text-gray-600">{pr.prNumber}</p>
           {pr.po && <p className="text-sm text-gray-500">Linked to PO: {pr.po.poNumber}</p>}
+          {pr.po?.iom && <p className="text-sm text-gray-500">Linked to IOM: {pr.po.iom.iomNumber}</p>}
         </div>
         <div className="text-right">
-          <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getPRStatusColor(pr.status)}`}>{pr.status.replace("_", " ")}</span>
+          <Link href="/pr" className="text-sm font-medium text-blue-600 hover:text-blue-800 inline-block mb-2">
+            &larr; Back to PR List
+          </Link>
+          <div>
+            <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getPRStatusColor(pr.status)}`}>{pr.status.replace("_", " ")}</span>
+          </div>
           <p className="text-sm text-gray-500 mt-1">Created: {new Date(pr.createdAt!).toLocaleDateString()}</p>
         </div>
       </div>

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -31,7 +31,7 @@ export default function DashboardHeader() {
   const visibleNavLinks = navLinks.filter(link => link.show);
 
   return (
-    <header className="bg-white shadow-sm">
+    <header className="bg-white shadow-sm sticky top-0 z-50 w-full">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           <div className="flex items-center">

--- a/src/components/IOMPrintView.tsx
+++ b/src/components/IOMPrintView.tsx
@@ -66,18 +66,23 @@ export default function IOMPrintView({ iom }: IOMPrintViewProps) {
         <h2 className="text-lg font-bold underline uppercase tracking-wider">
           Inter Office Memo
         </h2>
+        <p className="text-md font-semibold mt-2">{iom.title}</p>
       </div>
 
       {/* Meta Info */}
-      <div className="flex justify-between items-start mb-6 text-sm">
+      <div className="flex justify-between items-start mb-4 text-sm">
         <div>
           <p><span className="font-bold">From:</span> {iom.from}</p>
           <p><span className="font-bold">To:</span> {iom.to}</p>
-          <p><span className="font-bold">SUB:</span> {iom.subject}</p>
         </div>
-        <div>
+        <div className="text-right">
+          {iom.iomNumber && <p><span className="font-bold">IOM No.:</span> {iom.iomNumber}</p>}
           {iom.createdAt && <p><span className="font-bold">Date:</span> {new Date(iom.createdAt).toLocaleDateString()}</p>}
         </div>
+      </div>
+
+      <div className="text-center mb-6 text-sm">
+        <p><span className="font-bold">SUB:</span> {iom.subject}</p>
       </div>
 
       {/* Body */}

--- a/src/components/POPrintView.tsx
+++ b/src/components/POPrintView.tsx
@@ -62,6 +62,7 @@ export default function POPrintView({ po }: POPrintViewProps) {
         <h2 className="text-lg font-bold underline uppercase tracking-wider">
           Purchase Order
         </h2>
+        <p className="text-md font-semibold mt-2">{po.title}</p>
       </div>
 
       {/* Meta Info */}

--- a/src/components/PRPrintView.tsx
+++ b/src/components/PRPrintView.tsx
@@ -83,6 +83,7 @@ export default function PRPrintView({ pr }: PRPrintViewProps) {
         <h2 className="text-lg font-bold underline uppercase tracking-wider">
           Payment Request
         </h2>
+        <p className="text-md font-semibold mt-2">{pr.title}</p>
       </div>
 
       {/* Meta Info */}

--- a/src/lib/pr.ts
+++ b/src/lib/pr.ts
@@ -105,14 +105,19 @@ export async function getPRById(id: string) {
       po: {
         include: {
           vendor: true,
-          items: true
-        }
+          items: true,
+          iom: {
+            select: {
+              iomNumber: true,
+            },
+          },
+        },
       },
       preparedBy: { select: { name: true, email: true } },
       requestedBy: { select: { name: true, email: true } },
       reviewedBy: { select: { name: true, email: true } },
       approvedBy: { select: { name: true, email: true } },
-    }
+    },
   });
 }
 


### PR DESCRIPTION
This commit introduces several UI improvements and feature enhancements across the IOM, PO, and PR modules.

Key changes include:
- Implemented a sticky header for the main application layout, ensuring the navigation menu is always accessible.
- Modernized the back button on the IOM, PO, and PR detail pages, moving it to the right side above the status indicator for a cleaner look.
- Updated the IOM print view to include the title and IOM number, and to center the subject line.
- Ensured consistency across PO and PR print views by adding the title to each.
- Added the linked IOM number to the PR detail view, providing more context when a PR is generated from a PO that originated from an IOM.