### PR TITLE
refactor: Restructure detail page headers for compact layout

### DIFF
--- a/src/app/iom/[id]/page.tsx
+++ b/src/app/iom/[id]/page.tsx
@@ -187,21 +187,19 @@ export default function IOMDetailPage() {
 
   return (
     <PageLayout title={iom.title}>
-      <div className="flex justify-between items-start mt-2 mb-4">
-        <div>
-          <p className="text-lg text-gray-600">{iom.iomNumber}</p>
-        </div>
-        <div className="text-right">
-          <Link href="/iom" className="inline-flex items-center gap-2 rounded-md bg-gray-200 px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-300 mb-2">
+      <div className="mb-4">
+        <div className="flex justify-between items-center">
+          <p className="text-lg font-semibold text-gray-800">{iom.iomNumber}</p>
+          <Link href="/iom" className="inline-flex items-center gap-2 rounded-md bg-gray-200 px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-300">
             <ArrowLeft className="h-4 w-4" />
             Back to IOM List
           </Link>
-          <div>
-            <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getIOMStatusColor(iom.status)}`}>
-              {iom.status.replace("_", " ")}
-            </span>
-          </div>
-          <p className="text-sm text-gray-500 mt-1">
+        </div>
+        <div className="flex justify-end items-center gap-4 mt-1">
+          <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getIOMStatusColor(iom.status)}`}>
+            {iom.status.replace("_", " ")}
+          </span>
+          <p className="text-sm text-gray-500">
             Created: {new Date(iom.createdAt!).toLocaleDateString()}
           </p>
         </div>

--- a/src/app/po/[id]/page.tsx
+++ b/src/app/po/[id]/page.tsx
@@ -226,30 +226,32 @@ export default function PODetailPage() {
 
   return (
     <PageLayout title={po.title}>
-      <div className="flex justify-between items-start mt-2 mb-4">
-        <div>
-          <p className="text-lg text-gray-600">{po.poNumber}</p>
-          {po.iom && (
-            <p className="text-sm text-gray-500">
-              Created from IOM: {po.iom.iomNumber}
-            </p>
-          )}
-        </div>
-        <div className="text-right">
-          <Link href="/po" className="inline-flex items-center gap-2 rounded-md bg-gray-200 px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-300 mb-2">
+      <div className="mb-4">
+        <div className="flex justify-between items-center">
+          <p className="text-lg font-semibold text-gray-800">{po.poNumber}</p>
+          <Link href="/po" className="inline-flex items-center gap-2 rounded-md bg-gray-200 px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-300">
             <ArrowLeft className="h-4 w-4" />
             Back to PO List
           </Link>
+        </div>
+        <div className="flex justify-between items-center mt-1">
           <div>
+            {po.iom && (
+              <p className="text-sm text-gray-500">
+                Created from IOM: {po.iom.iomNumber}
+              </p>
+            )}
+          </div>
+          <div className="flex items-center gap-4">
             <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getPOStatusColor(po.status)}`}>
               {po.status.replace("_", " ")}
             </span>
+            <p className="text-sm text-gray-500">
+              Created: {new Date(po.createdAt!).toLocaleDateString()}
+            </p>
           </div>
-          <p className="text-sm text-gray-500 mt-1">
-                Created: {new Date(po.createdAt!).toLocaleDateString()}
-              </p>
-            </div>
-          </div>
+        </div>
+      </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
           {/* Main Content */}

--- a/src/app/pr/[id]/page.tsx
+++ b/src/app/pr/[id]/page.tsx
@@ -183,21 +183,33 @@ export default function PRDetailPage() {
 
   return (
     <PageLayout title={pr.title}>
-      <div className="flex justify-between items-start mt-2 mb-4">
-        <div>
-          <p className="text-lg text-gray-600">{pr.prNumber}</p>
-          {pr.po && <p className="text-sm text-gray-500">Linked to PO: {pr.po.poNumber}</p>}
-          {pr.po?.iom && <p className="text-sm text-gray-500">Linked to IOM: {pr.po.iom.iomNumber}</p>}
-        </div>
-        <div className="text-right">
-          <Link href="/pr" className="inline-flex items-center gap-2 rounded-md bg-gray-200 px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-300 mb-2">
+      <div className="mb-4">
+        <div className="flex justify-between items-center">
+          <p className="text-lg font-semibold text-gray-800">{pr.prNumber}</p>
+          <Link href="/pr" className="inline-flex items-center gap-2 rounded-md bg-gray-200 px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-300">
             <ArrowLeft className="h-4 w-4" />
             Back to PR List
           </Link>
+        </div>
+        <div className="flex justify-between items-center mt-1">
           <div>
-            <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getPRStatusColor(pr.status)}`}>{pr.status.replace("_", " ")}</span>
+            {pr.po && (
+              <p className="text-sm text-gray-500">
+                Linked to PO: {pr.po.poNumber}
+              </p>
+            )}
+            {pr.po?.iom && (
+              <p className="text-sm text-gray-500">
+                Linked to IOM: {pr.po.iom.iomNumber}
+              </p>
+            )}
           </div>
-          <p className="text-sm text-gray-500 mt-1">Created: {new Date(pr.createdAt!).toLocaleDateString()}</p>
+          <div className="flex items-center gap-4">
+            <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getPRStatusColor(pr.status)}`}>{pr.status.replace("_", " ")}</span>
+            <p className="text-sm text-gray-500">
+              Created: {new Date(pr.createdAt!).toLocaleDateString()}
+            </p>
+          </div>
         </div>
       </div>
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">


### PR DESCRIPTION
This commit refactors the headers on the IOM, PO, and PR detail pages to use a more compact, two-row layout. This change addresses user feedback regarding excess vertical spacing and improves the overall visual organization of the page.

- The first row now contains the main document number on the left and the "Back to list" button on the right.
- The second row displays linked document numbers (if any) on the left, and the status and creation date on the right.
- This new structure is applied consistently across the IOM, PO, and PR detail pages.