### PR TITLE
feat: Redesign detail page headers and standardize back button

### DIFF
--- a/src/app/iom/[id]/page.tsx
+++ b/src/app/iom/[id]/page.tsx
@@ -72,7 +72,7 @@ export default function IOMDetailPage() {
 
   if (loading) {
     return (
-      <PageLayout title="Loading IOM...">
+      <PageLayout>
         <LoadingSpinner />
       </PageLayout>
     );
@@ -80,7 +80,7 @@ export default function IOMDetailPage() {
 
   if (!iom) {
     return (
-      <PageLayout title="IOM Not Found">
+      <PageLayout>
         <ErrorDisplay
           title="IOM Not Found"
           message={`Could not find an IOM with the ID: ${params.id}`}
@@ -186,22 +186,26 @@ export default function IOMDetailPage() {
   };
 
   return (
-    <PageLayout title={iom.title}>
-      <div className="mb-4">
+    <PageLayout>
+      {/* Page Header */}
+      <div className="mb-6">
         <div className="flex justify-between items-center">
-          <p className="text-lg font-semibold text-gray-800">{iom.iomNumber}</p>
-          <Link href="/iom" className="inline-flex items-center gap-2 rounded-md bg-gray-200 px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-300">
+          <h1 className="text-2xl font-bold text-gray-900">{iom.title}</h1>
+          <Link href="/iom" className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700">
             <ArrowLeft className="h-4 w-4" />
             Back to IOM List
           </Link>
         </div>
-        <div className="flex justify-end items-center gap-4 mt-1">
-          <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getIOMStatusColor(iom.status)}`}>
-            {iom.status.replace("_", " ")}
-          </span>
-          <p className="text-sm text-gray-500">
-            Created: {new Date(iom.createdAt!).toLocaleDateString()}
-          </p>
+        <div className="flex justify-between items-center mt-2">
+          <p className="text-lg font-semibold text-gray-800">{iom.iomNumber}</p>
+          <div className="flex items-center gap-4">
+            <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getIOMStatusColor(iom.status)}`}>
+              {iom.status.replace("_", " ")}
+            </span>
+            <p className="text-sm text-gray-500">
+              Created: {new Date(iom.createdAt!).toLocaleDateString()}
+            </p>
+          </div>
         </div>
       </div>
 

--- a/src/app/po/[id]/page.tsx
+++ b/src/app/po/[id]/page.tsx
@@ -115,7 +115,7 @@ export default function PODetailPage() {
 
   if (loading) {
     return (
-      <PageLayout title="Loading Purchase Order...">
+      <PageLayout>
         <LoadingSpinner />
       </PageLayout>
     );
@@ -124,7 +124,7 @@ export default function PODetailPage() {
   // Display a forbidden message if the user does not have permission
   if (!canViewPO) {
     return (
-      <PageLayout title="Access Denied">
+      <PageLayout>
         <ErrorDisplay
           title="Forbidden"
           message="You do not have permission to view this purchase order."
@@ -140,7 +140,7 @@ export default function PODetailPage() {
 
   if (!po) {
     return (
-      <PageLayout title="Purchase Order Not Found">
+      <PageLayout>
         <ErrorDisplay
           title="PO Not Found"
           message={`Could not find a Purchase Order with the ID: ${params.id}`}
@@ -225,19 +225,21 @@ export default function PODetailPage() {
   };
 
   return (
-    <PageLayout title={po.title}>
-      <div className="mb-4">
+    <PageLayout>
+      {/* Page Header */}
+      <div className="mb-6">
         <div className="flex justify-between items-center">
-          <p className="text-lg font-semibold text-gray-800">{po.poNumber}</p>
-          <Link href="/po" className="inline-flex items-center gap-2 rounded-md bg-gray-200 px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-300">
+          <h1 className="text-2xl font-bold text-gray-900">{po.title}</h1>
+          <Link href="/po" className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700">
             <ArrowLeft className="h-4 w-4" />
             Back to PO List
           </Link>
         </div>
-        <div className="flex justify-between items-center mt-1">
+        <div className="flex justify-between items-center mt-2">
           <div>
+            <p className="text-lg font-semibold text-gray-800">{po.poNumber}</p>
             {po.iom && (
-              <p className="text-sm text-gray-500">
+              <p className="text-sm text-gray-500 mt-1">
                 Created from IOM: {po.iom.iomNumber}
               </p>
             )}

--- a/src/app/pr/[id]/page.tsx
+++ b/src/app/pr/[id]/page.tsx
@@ -88,13 +88,13 @@ export default function PRDetailPage() {
   };
 
   if (loading) {
-    return <PageLayout title="Loading Payment Request..."><LoadingSpinner /></PageLayout>;
+    return <PageLayout><LoadingSpinner /></PageLayout>;
   }
 
   // Display forbidden message if user lacks permission
   if (!canViewPR) {
     return (
-      <PageLayout title="Access Denied">
+      <PageLayout>
         <ErrorDisplay
           title="Forbidden"
           message="You do not have permission to view this payment request."
@@ -110,7 +110,7 @@ export default function PRDetailPage() {
 
   if (!pr) {
     return (
-      <PageLayout title="Payment Request Not Found">
+      <PageLayout>
         <ErrorDisplay title="PR Not Found" message={`Could not find a Payment Request with the ID: ${params.id}`} />
         <div className="mt-6 text-center"><Link href="/pr" className="text-blue-600 hover:text-blue-800">&larr; Back to PR List</Link></div>
       </PageLayout>
@@ -182,24 +182,26 @@ export default function PRDetailPage() {
   };
 
   return (
-    <PageLayout title={pr.title}>
-      <div className="mb-4">
+    <PageLayout>
+      {/* Page Header */}
+      <div className="mb-6">
         <div className="flex justify-between items-center">
-          <p className="text-lg font-semibold text-gray-800">{pr.prNumber}</p>
-          <Link href="/pr" className="inline-flex items-center gap-2 rounded-md bg-gray-200 px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-300">
+          <h1 className="text-2xl font-bold text-gray-900">{pr.title}</h1>
+          <Link href="/pr" className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700">
             <ArrowLeft className="h-4 w-4" />
             Back to PR List
           </Link>
         </div>
-        <div className="flex justify-between items-center mt-1">
+        <div className="flex justify-between items-center mt-2">
           <div>
+            <p className="text-lg font-semibold text-gray-800">{pr.prNumber}</p>
             {pr.po && (
-              <p className="text-sm text-gray-500">
+              <p className="text-sm text-gray-500 mt-1">
                 Linked to PO: {pr.po.poNumber}
               </p>
             )}
             {pr.po?.iom && (
-              <p className="text-sm text-gray-500">
+              <p className="text-sm text-gray-500 mt-1">
                 Linked to IOM: {pr.po.iom.iomNumber}
               </p>
             )}

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -2,19 +2,15 @@ import DashboardHeader from "./DashboardHeader";
 
 interface PageLayoutProps {
   children: React.ReactNode;
-  title: string;
 }
 
-export default function PageLayout({ children, title }: PageLayoutProps) {
+export default function PageLayout({ children }: PageLayoutProps) {
   return (
     <div className="min-h-screen bg-gray-100">
       <DashboardHeader />
-      <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
-        <div className="px-4 sm:px-0">
-          <h1 className="text-3xl font-bold text-gray-900 py-4">{title}</h1>
-          {children}
-        </div>
-      </div>
+      <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+        {children}
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
This commit implements a significant redesign of the headers on the IOM, PO, and PR detail pages based on user feedback. It also standardizes the back button styling for consistency.

Key changes include:
- Restructured the detail page headers into a two-row layout to improve information hierarchy and reduce vertical space. The first row now contains the page title and the back button, while the second row contains document numbers, status, and other metadata.
- Removed the title from the main `PageLayout` component to allow for custom header implementations on each detail page.
- Restyled the back button on detail pages to be a solid blue button with an icon, consistent with other primary actions in the application.