### PR TITLE
feat: Add debugging view to dashboard

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -95,6 +95,24 @@ export default function DashboardPage() {
             />
           </div>
         )}
+
+        {/* --- DEBUGGING VIEW --- */}
+        <div className="p-4 bg-gray-100 border border-gray-300 rounded-lg">
+            <h2 className="text-lg font-bold">Debugging Information</h2>
+            <p><strong>Status:</strong> {status}</p>
+            <p><strong>IsLoading:</strong> {isLoading.toString()}</p>
+            <p><strong>IsError:</strong> {isError.toString()}</p>
+            <p><strong>User Role:</strong> {userRole || 'Not found'}</p>
+            <h3 className="font-bold mt-2">Stats Data:</h3>
+            <pre className="text-sm bg-white p-2 border rounded overflow-x-auto">
+                {JSON.stringify(stats, null, 2) || "No stats data"}
+            </pre>
+            <h3 className="font-bold mt-2">Error Object:</h3>
+            <pre className="text-sm bg-white p-2 border rounded overflow-x-auto">
+                {JSON.stringify(error, null, 2) || "No error"}
+            </pre>
+        </div>
+
         {stats && DashboardComponent && <DashboardComponent stats={stats} />}
         {stats && !DashboardComponent && (
            <div className="text-center text-gray-500">


### PR DESCRIPTION
This commit adds a temporary debugging view to the main dashboard page (`/dashboard`). This is intended to help diagnose a persistent issue where the dashboard appears as a blank screen for all users.

The debugging view displays the following information:
- Current authentication status
- Loading and error states from the data fetching query
- The detected user role
- The raw `stats` data object received from the API
- The raw `error` object if an error occurs

This will provide crucial information to identify the root cause of the rendering failure.