### PR TITLE
fix: Correct Total Spend KPI calculation

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -77,10 +77,11 @@ export async function GET() {
             where: { fulfilledAt: { not: null }, iomId: { not: null } },
             include: { iom: { select: { createdAt: true } } },
           }),
-          prisma.purchaseOrder.aggregate({
+          // Correctly calculate spend from PROCESSED Payment Requests
+          prisma.paymentRequest.aggregate({
             _sum: { grandTotal: true },
             where: {
-              status: { in: ["ORDERED", "DELIVERED"] },
+              status: 'PROCESSED',
               createdAt: {
                 gte: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
               },
@@ -121,7 +122,7 @@ export async function GET() {
         kpis = {
           avgIomApprovalTime: calculateAverageApprovalTime(ioms, 'APPROVED'),
           avgPoApprovalTime: calculateAverageApprovalTime(pos, 'APPROVED'),
-          avgPrApprovalTime: calculateAverageApprovalTime(prs, 'APPROVED'),
+          avgPrApprovalTime: calculateAverageApprovalTime(prs, 'PROCESSED'), // Also changed this to PROCESSED
           avgProcurementCycleTime: calculateProcurementCycleTime(fulfilledPOs),
           emergencyPurchaseRate: calculateEmergencyPurchaseRate(ioms),
           totalSpendThisMonth: monthlySpendResult._sum.grandTotal || 0,


### PR DESCRIPTION
This commit fixes a critical bug where the "Total Spend (This Month)" KPI on the Administrator dashboard was calculated incorrectly. It was previously summing the totals of Purchase Orders, which does not represent actual spend.

The logic has been corrected to calculate the total spend by summing the `grandTotal` of all `PaymentRequest` documents with a status of `PROCESSED` within the current calendar month. This provides an accurate measure of funds that have actually been paid out.

The logic for calculating the average approval time for Payment Requests has also been updated to use the `PROCESSED` status, ensuring consistency. The changes have been verified with the full test suite and a successful production build.